### PR TITLE
Add themes to style html emails

### DIFF
--- a/custom-styles/README
+++ b/custom-styles/README
@@ -1,0 +1,6 @@
+Custom CSS Styles
+#################
+
+Add or link to .css files to this folder and they will be selectable as HTML
+themes in the plugin's configuration form, which can be used to style HTML
+emails.


### PR DESCRIPTION
A new select input is added in the admin form for HTML theme to use; the list is taken from the deployed themes as per the `qa_admin_theme_options()` function and the default is the current site theme, as per `qa_opt(site_theme)`.

The user may also use custom .css files, which would be added in the plugin's `custom-styles/` folder and selectable from the same input, with names `Custom - <filename.css>`.

A `<style>` node is added to the footer of the email's html content, containing the contents of the entire `qa-styles.css` file of the configured theme.  The actual email's body content is wrapped around a `<div class="publish2email-body">` node (in order to override unwanted styling of `<body>` nodes from the CSS), which is given a default margin of 10px and left text-align.

The email body itself also now has all the minimum components of an HTML5 document, namely:

``` html
<DOCTYPE! html>
<html>
  <header></header>
  <body>
    <!-- email content wrapped with <div class="publish2email-body"> -->
  </body>
  <!-- optionally added if a style is selected/available -->
  <footer>
    <style>...</style>
  </footer>
</html>
```
