### PR TITLE
Escaped html inside text body if email is html

### DIFF
--- a/qa-publish-to-email.php
+++ b/qa-publish-to-email.php
@@ -346,7 +346,7 @@ class qa_publish_to_email_event
 			if ($params['format'] === 'html')
 				return $params['content'];
 			else
-				return '<pre>'.$text.'</pre>';
+				return '<pre>'.htmlspecialchars($text).'</pre>';
 		}
 		else
 		{


### PR DESCRIPTION
If there are html special characters in a text post, and that text post ends up in
an html email (i.e. because some other post in the email is html), then escape
those special characters with the htmlspecialchars function.
