### PR TITLE
Added missing qa-app-posts.php source

### DIFF
--- a/qa-publish-to-email.php
+++ b/qa-publish-to-email.php
@@ -336,6 +336,8 @@ class qa_publish_to_email_event
 
 	function qa_format_post($params, $ishtml)
 	{
+		require_once QA_INCLUDE_DIR.'qa-app-posts.php';
+
 		if (isset($params['text']))
 			$text = $params['text'];
 		else


### PR DESCRIPTION
Fixes #4

The function `qa_post_content_to_text` is used but the file in which
it's declared is not sourced. This is now fixed.
